### PR TITLE
fix: enable not work when pass a object pullingConfig params

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ class ReactNetworkDetect {
     );
 
     if (needsPolling) {
-      if (typeof pollingConfig === "object" && pollingConfig.enabled) {
+      if (typeof pollingConfig === "object") {
         this.pollingConfigs = { ...defaultConfig, ...pollingConfig };
       } else if (pollingConfig) {
         this.pollingConfigs = defaultConfig;


### PR DESCRIPTION
Hello, Bro~ Thanks for your work first of all.
This PR fix the scenario below:
When pass a object type pollingConfig params，It maybe better always using  pollingConfig override defaultConfig.
Because developers are possible to pass a object like:

```js

// pollingConfig params
{
  //...other field  & custom value
 enabled: false
}

```
Unexpectedly, detector instance will continue work and use default config instead of custom value.