### PR TITLE
types: fix return type UseOnlineEffectType

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export interface IPollingConfig {
 
 export type UseOnlineEffectType = (
   pollingOptions?: IPollingConfig | boolean
-) => void;
+) => { isOnline: boolean };
 
 export type TEffectiveType = "slow-2g" | "2g" | "3g" | "4g";
 export interface INetworkInformation extends NetworkInformation {


### PR DESCRIPTION
Hi, thx for the work on this package ! 
I noticed a small fix to make on useOnlineEffectType. It does not return void but an object `{ isOnline: boolean)` 